### PR TITLE
feat: Allow to specify additional change stream options in createAdapter

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -107,6 +107,11 @@ export interface MongoAdapterOptions {
    * @default false
    */
   addCreatedAtField: boolean;
+
+  /**
+   * Options to pass to the MongoDB change stream.
+   */
+  changeStreamOptions?: Partial<ChangeStreamOptions>;
 }
 
 /**
@@ -161,7 +166,7 @@ export function createAdapter(
   let isClosed = false;
   let adapters = new Map<string, MongoAdapter>();
   let changeStream: ChangeStream;
-  let changeStreamOpts: ChangeStreamOptions = {};
+  let changeStreamOpts: ChangeStreamOptions = opts.changeStreamOptions ?? {};
 
   const initChangeStream = () => {
     if (isClosed || (changeStream && !changeStream.closed)) {


### PR DESCRIPTION
This is required in some cases when the adapter watches changes from a cold sharded cluster with low change intensity. Stream events emission delays can be reduced by adjusting maxAwaitTimeMS and batchSize options for a change stream upon creation.

See [MongoDB docs](https://www.mongodb.com/docs/php-library/current/reference/method/MongoDBCollection-watch/) for more details